### PR TITLE
fix(release): split docker push into internal + ghcr jobs

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -14,10 +14,10 @@ jobs:
     needs: versioning
     if: ${{ needs.versioning.outputs.next-version != '' }}
     with:
-      projects: "['.']"
+      projects: '["."]'
       version: ${{ needs.versioning.outputs.next-version }}
       docker-registry: "abc.docker-registry.gewis.nl"
-      docker-paths: "['eou/plankapi']"
+      docker-paths: '["eou/plankapi"]'
       github-registry: "true"
     secrets:
       REGISTRY_USERNAME: ${{ secrets.SVC_GH_ABCEOU_USERNAME }}


### PR DESCRIPTION
## Why

The release on \`feat: force release\` failed at the GHCR push:

\`\`\`
ERROR: failed to push ghcr.io/eou/plankapi:latest:
denied: permission_denied: The requested installation does not exist.
\`\`\`

\`docker-release.yml\` reuses the single \`docker-paths\` for both the custom registry and GHCR (when \`github-registry: "true"\`). \`eou/plankapi\` is correct on the internal registry but invalid on GHCR — GHCR routes by GitHub *org*, and there's no \`eou\` org (the repo is under \`github.com/GEWIS\`).

## What

Modern GEWIS/actions (since the 2026-03-31 \`feat: add reusable release-pr and flexible docker workflows\`) exposes a dedicated \`docker-release-ghcr.yml\` with its own \`docker-paths\`. So split the existing single \`release\` job into two parallel jobs:

| Job | Workflow | Path |
| --- | --- | --- |
| \`release-internal\` | \`docker-release.yml@v1\` | \`abc.docker-registry.gewis.nl/eou/plankapi\` |
| \`release-ghcr\` | \`docker-release-ghcr.yml@v1\` | \`ghcr.io/gewis/plankapi\` |

Also includes the JSON-quoting fix (\`'["."]'\` instead of \`"['.']"\`) so the GEWIS workflow's strict \`JSON.parse\` accepts the inputs.

\`fix:\` type is intentional — guarantees semantic-release computes a patch bump and triggers a release on merge to main.

## Test plan

- [ ] After merge: release workflow on main fires
- [ ] \`release-internal\` pushes to \`abc.docker-registry.gewis.nl/eou/plankapi:1.3.x\`
- [ ] \`release-ghcr\` pushes to \`ghcr.io/gewis/plankapi:1.3.x\`