### PR TITLE
fix(release): switch to GHCR-only via docker-release-ghcr.yml

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -10,15 +10,10 @@ jobs:
     uses: GEWIS/actions/.github/workflows/versioning.yml@v1
 
   release:
-    uses: GEWIS/actions/.github/workflows/docker-release.yml@v1
+    uses: GEWIS/actions/.github/workflows/docker-release-ghcr.yml@v1
     needs: versioning
     if: ${{ needs.versioning.outputs.next-version != '' }}
     with:
       projects: '["."]'
+      docker-paths: '["gewis/plankapi"]'
       version: ${{ needs.versioning.outputs.next-version }}
-      docker-registry: "abc.docker-registry.gewis.nl"
-      docker-paths: '["eou/plankapi"]'
-      github-registry: "true"
-    secrets:
-      REGISTRY_USERNAME: ${{ secrets.SVC_GH_ABCEOU_USERNAME }}
-      REGISTRY_PASSWORD: ${{ secrets.SVC_GH_ABCEOU_PWD }}


### PR DESCRIPTION
## Why

The release for v1.3.0 failed at the GHCR push:

\`\`\`
ERROR: failed to push ghcr.io/eou/plankapi:latest:
denied: permission_denied: The requested installation does not exist.
\`\`\`

\`docker-release.yml\` reuses the single \`docker-paths\` for both the custom registry and GHCR. \`eou/plankapi\` is correct on \`abc.docker-registry.gewis.nl\` (team namespace) but invalid on GHCR — GHCR routes by GitHub *org*, and there's no \`eou\` org.

## What

Drop the internal registry entirely and switch to the dedicated GHCR-only workflow with the org-namespaced path:

\`\`\`yaml
release:
  uses: GEWIS/actions/.github/workflows/docker-release-ghcr.yml@v1
  with:
    projects: '["."]'
    docker-paths: '["gewis/plankapi"]'
    version: \${{ needs.versioning.outputs.next-version }}
\`\`\`

- No \`REGISTRY_USERNAME\`/\`REGISTRY_PASSWORD\` secrets needed — GHCR push uses \`GITHUB_TOKEN\`.
- \`fix:\` type so semantic-release computes a patch bump and triggers a release on merge.

## Test plan

- [ ] After merge: release workflow on main fires
- [ ] Image pushed to \`ghcr.io/gewis/plankapi:1.3.1\` (and \`:latest\`)