### PR TITLE
fix(card): pass required type field to createCard

### DIFF
--- a/src/planka.ts
+++ b/src/planka.ts
@@ -172,6 +172,7 @@ export default class Planka {
           listId,
         },
         body: {
+          type: 'project',
           name: card.title,
           position: 0,
         },


### PR DESCRIPTION
## Why

Trace logs after the v3 client bump show every \`createCard\` call returning 400:

\`\`\`
[TRACE] Planka - created card 178 status 400
[TRACE] Planka - created card 177 status 400
...
\`\`\`

Planka v2 split cards into two kinds and \`type\` is now a **required** body field on \`POST /api/lists/{listId}/cards\`:

\`\`\`json
"required": ["type", "name"],
"properties": {
  "type": { "enum": ["project", "story"] },
  ...
}
\`\`\`

I missed this in #85 — the migration kept the v1 body shape (\`name\`/\`position\` only) which is now rejected.

## Fix

Add \`type: 'project'\` to the request body. The email-to-card flow corresponds to plain "project" cards (the spec's example default); \`story\` is for user-story workflows with sub-issues which we don't use.